### PR TITLE
Really keepdb

### DIFF
--- a/cl/tests/runner.py
+++ b/cl/tests/runner.py
@@ -3,6 +3,7 @@ import sys
 import warnings
 from unittest import TestLoader
 
+from django.conf import settings
 from django.test.runner import DiscoverRunner
 from override_storage import override_storage
 
@@ -69,14 +70,59 @@ class TestRunner(DiscoverRunner):
         # See PR #5888 for more details.
         # parser.set_defaults(buffer=True)
 
-    def setup_databases(self, **kwargs):
+    def setup_databases(self, *args, **kwargs):
         # Force to always delete the database if it exists
         interactive = self.interactive
         self.interactive = False
+
         try:
-            return super().setup_databases(**kwargs)
+            if self.keepdb:
+                # --keepdb doesn't really work. See Django bug #25251:
+                # https://code.djangoproject.com/ticket/25251. In addition to
+                # TransactionTestCases, it appears TestCases can also delete
+                # migration data. To resolve that, this modifies the test
+                # runner to never run against the actual test database if we're
+                # trying to keep it. Instead, always run against a clone that
+                # gets destroyed at the end of testing.
+
+                # Because we don't want to run through migrations twice,
+                # we use the normal process to create the actual test database, then
+                # manually clone it and the parallel clones.
+                parallel = self.parallel
+                self.parallel = 1
+                old_config = super().setup_databases(*args, **kwargs)
+                self.parallel = parallel
+                # Create the clones ourselves
+                for c in (x for x, y, z in old_config if z):
+                    # Create test_database_clone and replace the real test database.
+                    db_clone_name = c.settings_dict["NAME"] + "_clone"
+                    with self.time_keeper.timed(f"  Cloning '{c.alias}'"):
+                        c.creation.clone_test_db(
+                            "clone", verbosity=self.verbosity
+                        )
+                    settings.DATABASES[c.alias]["NAME"] = db_clone_name
+                    c.settings_dict["NAME"] = db_clone_name
+                    # Create parallel clones.
+                    if parallel > 1:
+                        for index in range(1, self.parallel + 1):
+                            with self.time_keeper.timed(
+                                f"  Cloning '{c.alias}'"
+                            ):
+                                c.creation.clone_test_db(
+                                    str(index), verbosity=self.verbosity
+                                )
+                return old_config
+            else:
+                return super().setup_databases(*args, **kwargs)
         finally:
             self.interactive = interactive
+
+    def teardown_databases(self, *args, **kwargs):
+        keepdb = self.keepdb
+        # Always delete the cloned DBs.
+        self.keepdb = False
+        super().teardown_databases(*args, **kwargs)
+        self.keebdb = keepdb
 
     @override_storage()
     def run_tests(self, *args, **kwargs):


### PR DESCRIPTION
## Fixes
<!-- What bugs does this fix? Use this syntax to auto-close the issue: -->
<!-- https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!-- E.g.: "Fixes: #XYZ" -->
Doesn't fix anything.  In fact, it probably creates problems.

## Summary
<!-- What does this fix, how did you fix it, what approach did you take, what gotchas are there in your code or compromises did you make? -->
Just testing out my PR labeling hack.

## Deployment

**This PR should:**
<!-- The following labels control the deployment of this PR if they’re applied. -->
<!-- Please put an "X" in the box on ones that apply. -->

<!-- Check here if the entire deployment can be skipped -->
<!-- This might be the case for a small fix, a tweak to documentation or something like that. -->
- [X] `skip-deploy`
<!-- Check here if the web tier can be skipped -->
<!-- This is the case if you're working on code that doesn't affect the front end, like management commands, tasks, or documentation. -->
- [X ] `skip-web-deploy`
<!-- Check here if the deployment to celery can be skipped -->
<!--This is the case if you make no changes to tasks.py or the code that tasks rely on. -->
- [ X] `skip-celery-deploy`
<!-- check this if deployment to cron jobs can be skipped -->
<!-- This is the case if no changes are made that affect cronjobs. -->
- [ ] `skip-cronjob-deploy`
<!-- Deployment of daemons can be skipped -->
<!-- This is the case if you haven't updated daemons or the code they depend on. -->
- [ ] `skip-daemon-deploy`

<!-- **If deployment is required:** -->
<!-- What extra steps are needed to deploy this beyond the standard deploy? -->
<!-- Do scripts need to be run or things like that? -->
<!-- If this is more than a quick thing, a new issue should be created in our infra repo: https://github.com/freelawproject/infrastructure/issues/new (if you don’t have access to it, just put the steps here) -->
<!-- Please use an ordered list or delete this if no special steps are required: -->
1. Ooo, we'll find out.  I removed the space in one checkbox, I put the "X" to the left of the space in another, and I did the same but to the right in a third.
<!-- Thank you for contributing and filling out this form! -->
